### PR TITLE
feat(analytics): implement persistent UID and turn duration tracking

### DIFF
--- a/Dev5_courseProject_prototype/Assets/Art/Materials/MovementHighlight.mat
+++ b/Dev5_courseProject_prototype/Assets/Art/Materials/MovementHighlight.mat
@@ -132,8 +132,8 @@ Material:
     - _WorkflowMode: 1
     - _ZWrite: 0
     m_Colors:
-    - _BaseColor: {r: 1, g: 0.9277588, b: 0, a: 1}
-    - _Color: {r: 1, g: 0.9277588, b: 0, a: 1}
+    - _BaseColor: {r: 1, g: 0.9277588, b: 0, a: 0.49019608}
+    - _Color: {r: 1, g: 0.9277588, b: 0, a: 0.49019608}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
   m_BuildTextureStacks: []

--- a/Dev5_courseProject_prototype/Assets/Code/Scripts/GameLogger.cs
+++ b/Dev5_courseProject_prototype/Assets/Code/Scripts/GameLogger.cs
@@ -3,14 +3,15 @@ using System.Text;
 using UnityEngine;
 using UnityEngine.Networking;
 using Newtonsoft.Json;
+using System;
 
 public class GameLogger : MonoBehaviour
 {
     public static GameLogger Instance {get; private set;}
     [Header("Backend Settings")]
-    [SerializeField] private bool enableLogging = false;
+    [SerializeField] private bool enableLogging = true;
     [SerializeField] private string serverUrl = "http://localhost:3000/api/log";
-    [SerializeField] private string currentUserId = "Player_1";
+    private string currentUserId;
 
     private void Awake()
     {
@@ -18,11 +19,28 @@ public class GameLogger : MonoBehaviour
         {
             Instance = this;
             DontDestroyOnLoad(gameObject);
+            InitializeUserId();
         }
         else
         {
             Destroy(gameObject);
         }
+    }
+
+    private void InitializeUserId()
+    {
+        if (PlayerPrefs.HasKey("Player_UID"))
+        {
+            currentUserId = PlayerPrefs.GetString("Player_UID");
+        }
+        else
+        {
+            currentUserId = Guid.NewGuid().ToString();
+            PlayerPrefs.SetString("Player_UID", currentUserId);
+            PlayerPrefs.Save();
+        }
+        Debug.Log($"User ID loaded: {currentUserId}");
+        LogAction("SessionStart", new {timestamp = System.DateTime.Now.ToString()});
     }
 
     public void LogAction (string actionType, object payload)

--- a/Dev5_courseProject_prototype/Assets/Code/Scripts/TurnManager.cs
+++ b/Dev5_courseProject_prototype/Assets/Code/Scripts/TurnManager.cs
@@ -9,6 +9,7 @@ public class TurnManager : MonoBehaviour
 
     [field: SerializeField] public UnitTeam CurrentTurn {get; private set;} = UnitTeam.Player;
     [SerializeField] private int turnCounter = 1;
+    private float turnStartTime;
 
     private void Awake()
     {
@@ -23,6 +24,18 @@ public class TurnManager : MonoBehaviour
 
     public void EndTurn()
     {
+        float duration = Time.time - turnStartTime;
+
+        if (GameLogger.Instance != null)
+        {
+            GameLogger.Instance.LogAction("TurnEnd", new
+            {
+                team = CurrentTurn.ToString(),
+                round = turnCounter,
+                durationSeconds = duration
+            });
+        }
+
         if (CurrentTurn == UnitTeam.Player)
         {
             StartTurn(UnitTeam.Enemy);
@@ -36,6 +49,8 @@ public class TurnManager : MonoBehaviour
 
     private void StartTurn(UnitTeam team)
     {
+        turnStartTime = Time.time;
+
         CurrentTurn = team;
         Debug.Log($"Start turn: {team} (Round {turnCounter})");
 


### PR DESCRIPTION
Implemented tracking for specific user metrics required for data analysis.

- Updated GameLogger to generate and persist a unique GUID in PlayerPrefs.
- Updated TurnManager to calculate and log the duration of each turn.
- Logs 'SessionStart' and 'TurnEnd' events to the backend.